### PR TITLE
Improve forex transaction pairing and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   <a href="https://flutter.dev/" style="text-decoration:none" area-label="flutter">
     <img src="https://img.shields.io/badge/Platform-Flutter%203.29.2-blue">
   </a>
-  <a href="https://github.com/Donnie/Finease/releases/tag/v1.2.2" style="text-decoration:none" area-label="flutter">
-    <img src="https://img.shields.io/badge/Version-1.2.2-orange">
+  <a href="https://github.com/Donnie/Finease/releases/tag/v1.2.4" style="text-decoration:none" area-label="flutter">
+    <img src="https://img.shields.io/badge/Version-1.2.4-orange">
   </a>
   <a href="https://github.com/Donnie/Finease/actions/workflows/android_release.yml" style="text-decoration:none" area-label="flutter">
     <img src="https://github.com/Donnie/Finease/actions/workflows/android_release.yml/badge.svg">

--- a/lib/db/entries.dart
+++ b/lib/db/entries.dart
@@ -238,6 +238,16 @@ class EntryService {
     if (userNotes == null || userNotes.isEmpty) {
       userNotes = debitEntry.notes;
     }
+    
+    // Append credit account currency and amount to the notes
+    final creditCurrencySymbol = SupportedCurrency[creditEntry.creditAccount?.currency] ?? creditEntry.creditAccount?.currency ?? '';
+    final creditAmount = creditEntry.amount;
+    final creditInfo = '$creditCurrencySymbol$creditAmount';
+    
+    // Combine user notes with credit currency/amount info
+    final finalNotes = (userNotes != null && userNotes.isNotEmpty) 
+        ? '$userNotes ($creditInfo)'
+        : creditInfo;
 
     return Entry(
       id: debitEntry.id, // Use the debit entry's ID
@@ -245,9 +255,9 @@ class EntryService {
       debitAccount: debitEntry.debitAccount,
       creditAccountId: creditEntry.creditAccountId,
       creditAccount: creditEntry.creditAccount,
-      amount: debitEntry.amount, // Use debit amount to match debit currency
+      amount: debitEntry.amount,
       date: debitEntry.date ?? creditEntry.date,
-      notes: userNotes,
+      notes: finalNotes,
       createdAt: debitEntry.createdAt,
       updatedAt: creditEntry.updatedAt,
     );

--- a/lib/db/entries.dart
+++ b/lib/db/entries.dart
@@ -161,8 +161,121 @@ class EntryService {
     return entries;
   }
 
+  /// Merges forex transaction pairs into single entries for display
+  /// This method intelligently finds and merges forex pairs regardless of order
+  Future<List<Entry>> getMergedEntries({
+    DateTime? startDate,
+    DateTime? endDate,
+    int? accountId,
+  }) async {
+    final allEntries = await getAllEntries(
+      startDate: startDate,
+      endDate: endDate,
+      accountId: accountId,
+    );
+
+    // Sort by date descending
+    allEntries.sort((a, b) => (b.date ?? DateTime(0))
+        .compareTo(a.date ?? DateTime(0)));
+
+    final List<Entry> mergedEntries = [];
+    final Set<int> processedIds = {};
+
+    for (var entry in allEntries) {
+      // Skip if already processed
+      if (processedIds.contains(entry.id)) continue;
+
+      // Check if this is a forex pair entry
+      if (isForexPairEntry(entry)) {
+        // Try to find its pair
+        final pairedEntry = await findForexPairEntry(entry, allEntries);
+
+        if (pairedEntry != null) {
+          // Merge the two entries
+          final mergedEntry = _mergeForexEntries(entry, pairedEntry);
+          mergedEntries.add(mergedEntry);
+          processedIds.add(entry.id!);
+          processedIds.add(pairedEntry.id!);
+        } else {
+          // No pair found, add as-is (shouldn't happen, but handle gracefully)
+          mergedEntries.add(entry);
+          processedIds.add(entry.id!);
+        }
+      } else {
+        // Regular entry, add as-is
+        mergedEntries.add(entry);
+        processedIds.add(entry.id!);
+      }
+    }
+
+    return mergedEntries;
+  }
+
+  /// Merges two forex entries into a single display entry
+  Entry _mergeForexEntries(Entry entry1, Entry entry2) {
+    // Determine which entry is the debit side and which is credit side
+    final entry1IsDebitSide = _isForexAccount(entry1.creditAccount);
+    final entry2IsCreditSide = _isForexAccount(entry2.debitAccount);
+    final entry2IsDebitSide = _isForexAccount(entry2.creditAccount);
+    final entry1IsCreditSide = _isForexAccount(entry1.debitAccount);
+
+    Entry debitEntry, creditEntry;
+    if (entry1IsDebitSide && entry2IsCreditSide) {
+      debitEntry = entry1;
+      creditEntry = entry2;
+    } else if (entry2IsDebitSide && entry1IsCreditSide) {
+      debitEntry = entry2;
+      creditEntry = entry1;
+    } else {
+      // Fallback: use entry1 as debit, entry2 as credit
+      debitEntry = entry1;
+      creditEntry = entry2;
+    }
+
+    // Get the user's notes (from the credit side entry, which usually has user notes)
+    String? userNotes = creditEntry.notes;
+    // If credit side has no notes, try the debit side
+    if (userNotes == null || userNotes.isEmpty) {
+      userNotes = debitEntry.notes;
+    }
+
+    return Entry(
+      id: debitEntry.id, // Use the debit entry's ID
+      debitAccountId: debitEntry.debitAccountId,
+      debitAccount: debitEntry.debitAccount,
+      creditAccountId: creditEntry.creditAccountId,
+      creditAccount: creditEntry.creditAccount,
+      amount: debitEntry.amount, // Use debit amount to match debit currency
+      date: debitEntry.date ?? creditEntry.date,
+      notes: userNotes,
+      createdAt: debitEntry.createdAt,
+      updatedAt: creditEntry.updatedAt,
+    );
+  }
+
   Future<int> updateEntry(Entry entry) async {
     final dbClient = await _databaseHelper.db;
+    
+    // Check if this is a forex pair entry
+    if (isForexPairEntry(entry)) {
+      // Get all entries to find the pair
+      final allEntries = await getAllEntries();
+      final pairedEntry = await findForexPairEntry(entry, allEntries);
+      
+      if (pairedEntry != null) {
+        // Update the paired entry's date to match
+        if (entry.date != null && pairedEntry.date != entry.date) {
+          pairedEntry.date = entry.date;
+          await dbClient.update(
+            'Entries',
+            pairedEntry.toJson(),
+            where: 'id = ?',
+            whereArgs: [pairedEntry.id],
+          );
+        }
+      }
+    }
+    
     return await dbClient.update(
       'Entries',
       entry.toJson(),
@@ -171,8 +284,81 @@ class EntryService {
     );
   }
 
+  /// Checks if an account is a forex account (name="Forex" and hidden=true)
+  bool _isForexAccount(Account? account) {
+    return account != null &&
+        account.name == "Forex" &&
+        account.hidden == true;
+  }
+
+
+  /// Checks if an entry is part of a forex transaction pair
+  bool isForexPairEntry(Entry entry) {
+    return _isForexAccount(entry.debitAccount) ||
+        _isForexAccount(entry.creditAccount);
+  }
+
+  /// Finds the paired entry for a forex transaction
+  /// Returns null if no pair is found
+  Future<Entry?> findForexPairEntry(Entry entry, List<Entry> allEntries) async {
+    // Match by timestamp (within 1 second) and forex account pattern
+    if (!isForexPairEntry(entry)) return null;
+
+    final isDebitSide = _isForexAccount(entry.creditAccount);
+    final isCreditSide = _isForexAccount(entry.debitAccount);
+
+    if (!isDebitSide && !isCreditSide) return null;
+
+    for (var otherEntry in allEntries) {
+      if (otherEntry.id == entry.id) continue;
+      if (!isForexPairEntry(otherEntry)) continue;
+
+      // Check if timestamps match (within 1 second)
+      if (entry.date != null && otherEntry.date != null) {
+        final timeDiff = (entry.date!.millisecondsSinceEpoch -
+                otherEntry.date!.millisecondsSinceEpoch)
+            .abs();
+        if (timeDiff > 1000) continue; // More than 1 second apart
+      }
+
+      // Match pattern: one entry has forex as credit, other has forex as debit
+      final otherIsDebitSide = _isForexAccount(otherEntry.creditAccount);
+      final otherIsCreditSide = _isForexAccount(otherEntry.debitAccount);
+
+      if (isDebitSide && otherIsCreditSide) {
+        // This entry: RealAccount -> ForexAccount
+        // Other entry: ForexAccount -> RealAccount
+        return otherEntry;
+      } else if (isCreditSide && otherIsDebitSide) {
+        // This entry: ForexAccount -> RealAccount
+        // Other entry: RealAccount -> ForexAccount
+        return otherEntry;
+      }
+    }
+
+    return null;
+  }
+
   Future<int> deleteEntry(int id) async {
     final dbClient = await _databaseHelper.db;
+    
+    // Get the entry first to check if it's part of a forex pair
+    final entry = await getEntry(id);
+    if (entry != null && isForexPairEntry(entry)) {
+      // Get all entries to find the pair
+      final allEntries = await getAllEntries();
+      final pairedEntry = await findForexPairEntry(entry, allEntries);
+      
+      if (pairedEntry != null && pairedEntry.id != null) {
+        // Delete both entries
+        await dbClient.delete(
+          'Entries',
+          where: 'id = ?',
+          whereArgs: [pairedEntry.id],
+        );
+      }
+    }
+    
     return await dbClient.delete(
       'Entries',
       where: 'id = ?',

--- a/lib/db/entries.dart
+++ b/lib/db/entries.dart
@@ -294,11 +294,51 @@ class EntryService {
     );
   }
 
+  /// Updates both entries in a forex pair with the same date
+  /// Only updates the credit entry's notes (user notes)
+  Future<void> updateForexPair({
+    required Entry debitEntry,
+    required Entry creditEntry,
+    required DateTime date,
+    required String? creditNotes,
+  }) async {
+    final dbClient = await _databaseHelper.db;
+    
+    // Update both entries' dates
+    debitEntry.date = date;
+    creditEntry.date = date;
+    
+    // Only update credit entry's notes (user notes)
+    if (creditNotes != null) {
+      creditEntry.notes = creditNotes;
+    }
+    
+    // Update both entries in the database
+    await dbClient.update(
+      'Entries',
+      debitEntry.toJson(),
+      where: 'id = ?',
+      whereArgs: [debitEntry.id],
+    );
+    
+    await dbClient.update(
+      'Entries',
+      creditEntry.toJson(),
+      where: 'id = ?',
+      whereArgs: [creditEntry.id],
+    );
+  }
+
   /// Checks if an account is a forex account (name="Forex" and hidden=true)
   bool _isForexAccount(Account? account) {
     return account != null &&
         account.name == "Forex" &&
         account.hidden == true;
+  }
+
+  /// Public method to check if an account is a forex account
+  bool isForexAccount(Account? account) {
+    return _isForexAccount(account);
   }
 
 

--- a/lib/pages/add_entry/date_time.dart
+++ b/lib/pages/add_entry/date_time.dart
@@ -26,6 +26,14 @@ class DateTimePickerState extends State<DateTimePicker> {
     selectedDateTime = widget.dateTime ?? DateTime.now();
   }
 
+  @override
+  void didUpdateWidget(DateTimePicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.dateTime != oldWidget.dateTime) {
+      selectedDateTime = widget.dateTime ?? DateTime.now();
+    }
+  }
+
   void _pickDateTime() async {
     final DateTime? pickedDateNullable = await showDatePicker(
       context: context,
@@ -59,29 +67,52 @@ class DateTimePickerState extends State<DateTimePicker> {
     widget.onDateTimeChanged(combinedDateTime);
   }
 
+  void _resetDateTime() {
+    final now = DateTime.now();
+    setState(() {
+      selectedDateTime = now;
+    });
+    widget.onDateTimeChanged(now);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ElevatedButton(
-          onPressed: _pickDateTime,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 16.0,
-              vertical: 16,
+        Row(
+          children: [
+            Expanded(
+              child: ElevatedButton(
+                onPressed: _pickDateTime,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16.0,
+                    vertical: 16,
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(MdiIcons.calendar),
+                      const SizedBox(width: 16),
+                      Text(
+                        DateFormat('yyyy-MM-dd HH:mm').format(selectedDateTime),
+                        style: context.bodyLarge,
+                      )
+                    ],
+                  ),
+                ),
+              ),
             ),
-            child: Row(
-              children: [
-                Icon(MdiIcons.calendar),
-                const SizedBox(width: 16),
-                Text(
-                  DateFormat('yyyy-MM-dd HH:mm').format(selectedDateTime),
-                  style: context.bodyLarge,
-                )
-              ],
+            const SizedBox(width: 8),
+            IconButton(
+              onPressed: _resetDateTime,
+              icon: Icon(MdiIcons.restore),
+              tooltip: 'Reset to current time',
+              style: IconButton.styleFrom(
+                padding: const EdgeInsets.all(16),
+              ),
             ),
-          ),
+          ],
         ),
       ],
     );

--- a/lib/pages/edit_entry/main.dart
+++ b/lib/pages/edit_entry/main.dart
@@ -37,12 +37,35 @@ class EditEntryScreenState extends State<EditEntryScreen> {
 
   Future<void> loadEntry(int id) async {
     Entry? entry = await _entryService.getEntry(id);
+    if (entry == null) return;
+    
+    // For forex transactions, get the credit entry's notes (user's actual notes)
+    String? displayNotes = entry.notes;
+    if (_entryService.isForexPairEntry(entry)) {
+      final allEntries = await _entryService.getAllEntries();
+      final pairedEntry = await _entryService.findForexPairEntry(entry, allEntries);
+      
+      if (pairedEntry != null) {
+        // Determine which is the credit entry (the one with user notes)
+        final isDebitSide = _entryService.isForexAccount(entry.creditAccount);
+        final isCreditSide = _entryService.isForexAccount(entry.debitAccount);
+        
+        if (isDebitSide) {
+          // This entry is debit side, paired entry is credit side (has user notes)
+          displayNotes = pairedEntry.notes;
+        } else if (isCreditSide) {
+          // This entry is credit side (has user notes)
+          displayNotes = entry.notes;
+        }
+      }
+    }
+    
     setState(() {
-      _entry = entry!;
+      _entry = entry;
       _entryDate = entry.date;
       _creditAccount = entry.creditAccount;
       _debitAccount = entry.debitAccount;
-      _entryNotes.text = entry.notes ?? '';
+      _entryNotes.text = displayNotes ?? '';
     });
   }
 
@@ -85,9 +108,53 @@ class EditEntryScreenState extends State<EditEntryScreen> {
     String entryNotes = _entryNotes.text;
     if (_formState.currentState?.validate() ?? false) {
       context.pop();
-      _entry!.date = _entryDate ?? _entry!.date;
-      _entry!.notes = entryNotes;
-      await _entryService.updateEntry(_entry!);
+      
+      final newDate = _entryDate ?? _entry!.date ?? DateTime.now();
+      
+      // For forex transactions, update the credit entry's notes and sync dates on both entries
+      if (_entryService.isForexPairEntry(_entry!)) {
+        final allEntries = await _entryService.getAllEntries();
+        final pairedEntry = await _entryService.findForexPairEntry(_entry!, allEntries);
+        
+        if (pairedEntry != null) {
+          final isDebitSide = _entryService.isForexAccount(_entry!.creditAccount);
+          final isCreditSide = _entryService.isForexAccount(_entry!.debitAccount);
+          
+          Entry debitEntry, creditEntry;
+          if (isDebitSide) {
+            // Loaded entry is debit side
+            debitEntry = _entry!;
+            creditEntry = pairedEntry;
+          } else if (isCreditSide) {
+            // Loaded entry is credit side
+            debitEntry = pairedEntry;
+            creditEntry = _entry!;
+          } else {
+            // Fallback: treat current entry as debit
+            debitEntry = _entry!;
+            creditEntry = pairedEntry;
+          }
+          
+          // Update both entries' dates and only credit entry's notes
+          await _entryService.updateForexPair(
+            debitEntry: debitEntry,
+            creditEntry: creditEntry,
+            date: newDate,
+            creditNotes: entryNotes,
+          );
+        } else {
+          // Fallback: update the current entry
+          _entry!.date = newDate;
+          _entry!.notes = entryNotes;
+          await _entryService.updateEntry(_entry!);
+        }
+      } else {
+        // Regular entry
+        _entry!.date = newDate;
+        _entry!.notes = entryNotes;
+        await _entryService.updateEntry(_entry!);
+      }
+      
       widget.onFormSubmitted();
     }
   }

--- a/lib/pages/home/entries/entry_card.dart
+++ b/lib/pages/home/entries/entry_card.dart
@@ -49,7 +49,7 @@ class EntryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final String symbol = SupportedCurrency[entry.creditAccount!.currency]!;
+    final String symbol = SupportedCurrency[entry.debitAccount!.currency]!;
     final cardColor = entry.creditAccount?.type == AccountType.expense ? context.secondaryContainer : context.tertiaryContainer;
 
     return InkWell(

--- a/lib/pages/home/entries/main.dart
+++ b/lib/pages/home/entries/main.dart
@@ -116,54 +116,17 @@ class EntriesPageState extends State<EntriesPage> {
   }
 
   Future<void> loadEntries() async {
-    List<Entry> entriesList = await _entryService.getAllEntries(
+    // Use the improved merging algorithm from EntryService
+    List<Entry> mergedEntries = await _entryService.getMergedEntries(
       startDate: widget.startDate,
       endDate: widget.endDate,
       accountId: widget.accountID,
     );
-    entriesList.sort((a, b) => (b.date!.compareTo(a.date!)));
-
-    List<Entry> mergedEntries = [];
-    for (int i = 0; i < entriesList.length; i++) {
-      Entry creditEntry = entriesList[i];
-      bool merged = false;
-
-      // Check if the next entry exists and if it's within a 1-second interval
-      if (i < entriesList.length - 1) {
-        Entry debitEntry = entriesList[i + 1];
-        if ((creditEntry.date! == debitEntry.date!) &&
-            // name because in multi currency trans only name is same, ids are diff.
-            debitEntry.creditAccount!.name == creditEntry.debitAccount!.name) {
-          Entry mergedEntry = mergeEntries(debitEntry, creditEntry);
-          mergedEntries.add(mergedEntry);
-          i++; // Skip the next entry as it's merged
-          merged = true;
-        }
-      }
-
-      // Add the current entry if it's not merged
-      if (!merged) {
-        mergedEntries.add(creditEntry);
-      }
-    }
 
     // Update state
     setState(() {
       entries = mergedEntries;
     });
-  }
-
-  Entry mergeEntries(Entry entry1, Entry entry2) {
-    return Entry(
-      id: entry1.id,
-      debitAccountId: entry1.debitAccountId,
-      debitAccount: entry1.debitAccount,
-      creditAccountId: entry2.creditAccountId,
-      creditAccount: entry2.creditAccount,
-      amount: entry2.amount,
-      date: entry1.date,
-      notes: entry2.notes,
-    );
   }
 
   List<Map<String, dynamic>> getTopExpenses() {

--- a/lib/pages/home/summary/widgets.dart
+++ b/lib/pages/home/summary/widgets.dart
@@ -292,7 +292,7 @@ class NetWorthGraphCard extends StatelessWidget {
                         interval: (maxY - minY) / 5,
                         getTitlesWidget: (value, meta) {
                           return Text(
-                            '${symbol}${(value / 1000).toStringAsFixed(0)}k',
+                            '$symbol${(value / 1000).toStringAsFixed(0)}k',
                             style: context.bodySmall?.copyWith(
                               color: context.onSurface.withOpacity(0.6),
                             ),
@@ -333,7 +333,7 @@ class NetWorthGraphCard extends StatelessWidget {
                         return touchedSpots.map((LineBarSpot touchedSpot) {
                           final index = touchedSpot.x.toInt();
                           return LineTooltipItem(
-                            '${symbol}${touchedSpot.y.toStringAsFixed(2)}\n${monthLabels[index]}',
+                            '$symbol${touchedSpot.y.toStringAsFixed(2)}\n${monthLabels[index]}',
                             (context.bodyMedium ?? const TextStyle()).copyWith(
                               color: Colors.white,
                               fontWeight: FontWeight.bold,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: finease
 description: "A full stack mobile app to keep track of financial transactions"
 publish_to: 'none'
-version: 1.2.2
+version: 1.2.4
 
 environment:
   sdk: '>=3.2.3 <4.0.0'


### PR DESCRIPTION
Enhanced forex transaction handling to correctly merge and display multi-currency transactions.

**Changes:**
- Improved matching algorithm: Finds forex pairs by timestamp (within 1 second) and account pattern, searches entire list instead of just consecutive entries
- Enhanced deletion: Automatically deletes both entries in a forex pair
- Display improvements: Shows debit account currency/amount, appends credit currency/amount to notes
- Edit handling: Updates both entries' dates when editing forex transactions

**Result:** Forex transactions like 'Social → Forex' + 'Forex → Axis' now correctly merge into a single 'Social → Axis' entry with both amounts visible.